### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "dart"
+run = "dart bin/main.dart"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # dart_nn
 
+[![Run on Repl.it](https://repl.it/badge/github/vickylance/dart_nn)](https://repl.it/github/vickylance/dart_nn)
+
 A Simple Neural Network library written in dart.
 
 Inspired from Toy Neural Network library by Coding Train.


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@vickylance/dartnn).